### PR TITLE
adds range tests to compare accuracy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ ndarray = "0.15.4"
 
 [dev-dependencies]
 criterion = "0.3.6"
+proptest = { version = "1.0.0" }
 
 [[bench]]
 name = "ln_benchmark"

--- a/proptest-regressions/ln.txt
+++ b/proptest-regressions/ln.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc a34a4f07233faadcc35a0698aee0db5dfc6fcce22dbdf92522e313d8e5339506 # shrinks to x = 1000000

--- a/proptest-regressions/ln_tables.txt
+++ b/proptest-regressions/ln_tables.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 44afd62b775700c847ee3d4410c03bce92da916b5cb31b292e2bc148aba237bf # shrinks to x = 340282366920939


### PR DESCRIPTION
of note, ln tables lookup will overflow at around u64::MAX >> 4, so the iterative approach is much better for accuracy IMO (up to around 9 decimal places)